### PR TITLE
fix swatches duplicating when adding flexible content rows

### DIFF
--- a/assets/acf-restrict-color-picker.js
+++ b/assets/acf-restrict-color-picker.js
@@ -4,12 +4,16 @@
 
     acf.add_action('ready append', function() {
         acf.get_fields({type : 'color_picker'}).each(function() {
-            $(this).iris({
-                palettes: JSON.parse(acfRCPOptions.colorPickerOptions),
-                change: function(event, ui) {
-                    $(this).parents('.wp-picker-container').find('.wp-color-result').css('background-color', ui.color.toString());
-                }
-            });
+
+            if ( $(this).data('initialised') != true ) {
+                $(this).iris({
+                    palettes: JSON.parse(acfRCPOptions.colorPickerOptions),
+                    change: function(event, ui) {
+                        $(this).parents('.wp-picker-container').find('.wp-color-result').css('background-color', ui.color.toString());
+                    }
+                });
+                $(this).data('initialised', true);
+            }
         });
     });
 


### PR DESCRIPTION
The plugin was add new duplicate swatches to existing color picker fields when adding a row to a flexible content field when editing a page.

Added a small check in the JS to stop iris being setup multiple times for any color picker field