### PR TITLE
Fixes PHP 8.2 dynamic properties deprecation

### DIFF
--- a/acf-restrict-color-picker.php
+++ b/acf-restrict-color-picker.php
@@ -36,6 +36,7 @@ class ACF_Restrict_Color_Picker_Options {
 	private $plugin_url;
 	private $color_settings;
 	private $theme_color_palette;
+	private $settings;
 
 	/**
 	 * Initialize plugin


### PR DESCRIPTION
PHP 8.2 deprecates dynamic properties in objects - all properties should declared explicitly