### PR TITLE
Fixed PHP Notice: Creation of dynamic property ACF_Restrict_Color_Picker_Options::$settings is deprecated.

### DIFF
--- a/acf-restrict-color-picker.php
+++ b/acf-restrict-color-picker.php
@@ -34,7 +34,7 @@ class ACF_Restrict_Color_Picker_Options {
 
 	private $plugin_path;
 	private $plugin_url;
-	private $color_settings;
+	private $settings;
 	private $theme_color_palette;
 
 	/**


### PR DESCRIPTION
Problem
- Since PHP 8.2, the plugin acf-restrict-color-picker triggers a PHP deprecation warning, because it sets a class property that is not defined.

Details
- A class property exists, but it was defined with a prefix that is not actually used.
- The problem was also reported in the support forum: https://wordpress.org/support/topic/php-8-2-8-settings-is-deprecated/

Proposed solution
1. Correct the class property name.
2. Publish a new release 1.3.2.

Closes https://github.com/VitalDevTeam/acf-restrict-color-picker/pull/3


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210409185753112